### PR TITLE
Add German Occidentalist

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,6 +331,8 @@
           <div class="col-md-4">
             <h3>Li Jurnal IE-Munde</h3>
             <p><a href="https://www.ie-munde.com/jurnal-ie-munde.html">2010-2014</a></p>
+	    <h3>German Occidentalist</h3>
+            <p><a href="https://occidental-lang.com/german-occidentalist/">1933-1935</a></p>
           </div>
         </div>
         <div class="row text-center">

--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@
             <h3>Cosmoglotta</h3>
             <ul class="list-unstyled">
               <li><a href="https://occidental-lang.com/cosmoglotta/">Cosmoglotta (1927-1950, typed with updated orthography)</a></li>
-              <li><a href="https://www.ie-munde.com/cosmoglotta.html">Modern Cosmoglotta (~2014)</a> (example issue from <a href="resources/Cg_328_2021_2.pdf">December 2021</a>)</li>
+              <li><a href="https://web.archive.org/web/20231211031219/https://www.ie-munde.com/cosmoglotta.html">Modern Cosmoglotta (~2014)</a> (example issue from <a href="resources/Cg_328_2021_2.pdf">December 2021</a>)</li>
             </ul>
           </div>
           <div class="col-md-4">
@@ -330,7 +330,7 @@
           </div>
           <div class="col-md-4">
             <h3>Li Jurnal IE-Munde</h3>
-            <p><a href="https://www.ie-munde.com/jurnal-ie-munde.html">2010-2014</a></p>
+            <p><a href="https://web.archive.org/web/20231211032038/https://www.ie-munde.com/jurnal-ie-munde.html">2010-2014</a></p>
 	    <h3>German Occidentalist</h3>
             <p><a href="https://occidental-lang.com/german-occidentalist/">1933-1935</a></p>
           </div>
@@ -403,9 +403,9 @@ Li sercha in li castelle Dewahl e altri racontas by Vicente Costalago</a></li>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="https://www.ie-munde.com/">
+            <a href="https://web.archive.org/web/20231211022359/https://www.ie-munde.com/benevenit.html">
               <img src="img/logowerner.png" alt="official union logo" height="50px" class="img-circle">
-              <p>Official Language Union Website</p>
+              <p>Official Language Union Website (archived)</p>
             </a>
           </div>
         </div>


### PR DESCRIPTION
This adds a link to transcripts of the publication *German Occidentalist* to the "Read" section.

* The mdBook containing the transcripts can be found in this repo: https://github.com/SineLaude/german-occidentalist
* Live preview: https://sinelaude.github.io/german-occidentalist/

The newly added link has https://occidental-lang.com/german-occidentalist/ as its destination, so the German Occidentalist repo should be cloned to occidental-lang, deployed from the `docs` directory via GitHub Pages and made available under that URL.

(In a separate commit, this also fixes a few links to the IE Munde website by substituting WebArchive URLs.)